### PR TITLE
using 'id' from task even when not configured

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,7 +30,7 @@ function Queue(process, opts) {
   self.filter = opts.filter || function (input, cb) { cb(null, input) };
   self.merge = opts.merge || function (oldTask, newTask, cb) { cb(null, newTask) };
   self.precondition = opts.precondition || function (cb) { cb(null, true) };
-  self.id = opts.id || false;
+  self.id = opts.id || 'id';
   self.priority = opts.priority || null;
 
   self.cancelIfRunning = (opts.cancelIfRunning === undefined ? false : !!opts.cancelIfRunning);
@@ -276,7 +276,7 @@ Queue.prototype.push = function (input, cb) {
         if (err) return ticket.failed('id_error');
         acceptTask(id);
       })
-    } else if (typeof self.id === 'string' && typeof task === 'object') {
+    } else if (typeof self.id === 'string' && typeof task === 'object' && task[self.id] !== undefined ) {
       acceptTask(task[self.id])
     } else {
       acceptTask();


### PR DESCRIPTION
To make it compatible to what was mentioned in the readme file