### PR TITLE
making the better-queue-sql/better-queue-sqlite dependency explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,8 @@ var q = new Queue(fn, {
 });
 ```
 
+Note that this requires `better-queue-sql` or `better-queue-sqlite`.
+
 #### PostgreSQL store (`npm install pg`)
 ```
 var q = new Queue(fn, {


### PR DESCRIPTION
Error messages `Error: Attempting to require better-queue-sql, but failed. Please ensure you have this store installed via npm install --save better-queue-sql` help but could be easier to have this in the documentation to avoid the error altogether.