### PR TITLE
Throw proper JS Error when `maxTimeout` is reached

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -602,7 +602,7 @@ Queue.prototype._startBatch = function (batch, tickets, lockId) {
 
   if (self.maxTimeout < Infinity) {
     timeout = setTimeout(function () {
-      worker.failedBatch('task_timeout');
+      worker.failedBatch(new Error('task_timeout'));
     }, self.maxTimeout);
   }
   worker.on('task_failed', function (id, msg) {


### PR DESCRIPTION
- Fixes #82