### PR TITLE
Demonstrate average stats exceeding maxTimeout

### DIFF
--- a/test/complex.js
+++ b/test/complex.js
@@ -130,14 +130,19 @@ describe('Complex Queue', function() {
   it.only('should remove tasks taking longer than maxTimeout', function (done) {
     const maxTimeout = 1;
     const taskTime = 100;
-    const process = async () => {
-      return await new Promise((resolve) => setTimeout(resolve, taskTime));
+    const process = async (task, cb) => {
+      await new Promise((resolve) => setTimeout(resolve, taskTime));
+      cb();
     }
     const q = new Queue(process, { maxTimeout })
 
     let counter = 0;
     const maxCounter = 500;
-    const push = () => q.push(1);
+    const push = () => {
+      for(let i = 0; i < 100; i++) {
+        q.push(1);
+      }
+    }
     q.on('task_failed', function (taskId, msg) {
       if (counter < maxCounter) {
         counter++;


### PR DESCRIPTION
Demonstrates the effect documented in #81. But it's not super significant actually... I thought I could manipulate `average` arbitrarily, but so far I didn't manage. Seems more like a slip in the calculation somewhere or that it's not exactly killed after maxTimeout was reached.

```bash

> better-queue@3.8.10 test /Users/timdaub/Projects/better-queue
> mocha



  Complex Queue
    1) should remove tasks taking longer than maxTimeout


  0 passing (1s)
  1 failing

  1) Complex Queue should remove tasks taking longer than maxTimeout:

      Uncaught AssertionError [ERR_ASSERTION]: maxTimeout was set to "1" but average task processing time is "1.3592814371257484"
      + expected - actual

      -false
      +true

      at Queue.<anonymous> (test/complex.js:148:9)
      at Worker.<anonymous> (lib/queue.js:620:12)
      at Worker.failedTask (lib/worker.js:137:10)
      at lib/worker.js:124:10
      at Array.forEach (<anonymous>)
      at Worker.failedBatch (lib/worker.js:122:30)
      at Timeout._onTimeout (lib/queue.js:605:14)
      at listOnTimeout (internal/timers.js:557:17)
      at processTimers (internal/timers.js:500:7)



npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! better-queue@3.8.10 test: `mocha`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the better-queue@3.8.10 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/timdaub/.npm/_logs/2022-06-30T07_41_27_553Z-debug.log

```